### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,14 @@ services:
       - 27017:27017
 
   zookeeper:
-    image: 'bitnami/zookeeper:3.9.2'
+    image: 'soldevelo/zookeeper:3.9.5'
     ports:
       - '2181:2181'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:3.7
+    image: docker.io/soldevelo/kafka:3.7
     ports:
       - "9092:9092"
     volumes:


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/zookeeper:3.9.2` → [`soldevelo/zookeeper:3.9.5`](https://hub.docker.com/r/soldevelo/zookeeper)
- `bitnami/kafka:3.7` → [`soldevelo/kafka:3.7`](https://hub.docker.com/r/soldevelo/kafka)